### PR TITLE
App Tracking Transparency Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["mParticle-Kochava"]),
     ],
     dependencies: [
-        .package(name: "mParticle-Apple-SDK", url: "git@github.com:mParticle/mparticle-apple-sdk.git", from: "8.0.1"),
+        .package(name: "mParticle-Apple-SDK", url: "git@github.com:mParticle/mparticle-apple-sdk.git", from: "8.2"),
         .package(
                     name: "KochavaCore",
                     url: "https://github.com/Kochava/Apple-SwiftPackage-KochavaCore",

--- a/mParticle-Kochava.podspec
+++ b/mParticle-Kochava.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "10.3"
     s.ios.source_files      = 'mParticle-Kochava/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '>= 8.2'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.2'
     s.ios.dependency 'KochavaTrackeriOS', '~> 4.0'
     s.ios.pod_target_xcconfig = {
         'LIBRARY_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/KochavaTrackeriOS/**',

--- a/mParticle-Kochava.podspec
+++ b/mParticle-Kochava.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "10.3"
     s.ios.source_files      = 'mParticle-Kochava/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '>= 8.2'
     s.ios.dependency 'KochavaTrackeriOS', '~> 4.0'
     s.ios.pod_target_xcconfig = {
         'LIBRARY_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/KochavaTrackeriOS/**',

--- a/mParticle-Kochava/MPKitKochava.h
+++ b/mParticle-Kochava/MPKitKochava.h
@@ -17,7 +17,7 @@ extern NSString * _Nonnull const MPKitKochavaEnhancedDeeplinkRawKey;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
 @property (nonatomic, strong, nullable) MPKitAPI *kitApi;
 
-- (void)retrieveAttributionWithCompletionHandler:(void(^)(NSDictionary *attribution))completionHandler;
+- (void)retrieveAttributionWithCompletionHandler:(void(^_Nullable)(NSDictionary * _Nonnull attribution))completionHandler;
 + (void)addCustomIdentityLinks:(nonnull NSDictionary *)identityLink;
 
 @end

--- a/mParticle-Kochava/MPKitKochava.m
+++ b/mParticle-Kochava/MPKitKochava.m
@@ -19,6 +19,9 @@ NSString *const kvEnableLogging = @"enableLogging";
 NSString *const kvLimitAdTracking = @"limitAdTracking";
 NSString *const kvLogScreenFormat = @"Viewed %@";
 NSString *const kvEcommerce = @"eCommerce";
+NSString *const kvEnableATT = @"enableATT";
+NSString *const kvEnableATTPrompt = @"enableATTPrompt";
+NSString *const kvWaitIntervalATT = @"waitIntervalATT";
 
 @interface MPKitKochava()
 
@@ -165,7 +168,17 @@ NSString *const kvEcommerce = @"eCommerce";
     _configuration = configuration;
     _started = YES;
     
-    KVATracker.shared.appTrackingTransparency.enabledBool = NO;
+    if (self.configuration[kvEnableATT]) {
+        KVATracker.shared.appTrackingTransparency.enabledBool = [self.configuration[kvEnableATT] boolValue] ? @YES : @NO;
+    }
+
+    if (self.configuration[kvEnableATTPrompt]) {
+        KVATracker.shared.appTrackingTransparency.autoRequestTrackingAuthorizationBool = [self.configuration[kvEnableATTPrompt] boolValue] ? @YES : @NO;
+        if (self.configuration[kvWaitIntervalATT] && [self.configuration[kvEnableATTPrompt] boolValue]) {
+            KVATracker.shared.appTrackingTransparency.authorizationStatusWaitTimeInterval = [self.configuration[kvWaitIntervalATT] integerValue];
+        }
+    }
+
     [KVATracker.shared startWithAppGUIDString:self.configuration[kvAppId]];
     
     if (self.configuration[kvLimitAdTracking]) {

--- a/mParticle-Kochava/MPKitKochava.m
+++ b/mParticle-Kochava/MPKitKochava.m
@@ -165,6 +165,7 @@ NSString *const kvEcommerce = @"eCommerce";
     _configuration = configuration;
     _started = YES;
     
+    KVATracker.shared.appTrackingTransparency.enabledBool = NO;
     [KVATracker.shared startWithAppGUIDString:self.configuration[kvAppId]];
     
     if (self.configuration[kvLimitAdTracking]) {
@@ -269,6 +270,12 @@ NSString *const kvEcommerce = @"eCommerce";
         
         [self->_kitApi onAttributionCompleteWithResult:attributionResult error:nil];
     }];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceKochava) returnCode:MPKitReturnCodeSuccess];
+}
+
+- (MPKitExecStatus *)setATTStatus:(MPATTAuthorizationStatus)status withATTStatusTimestampMillis:(NSNumber *)attStatusTimestampMillis  API_AVAILABLE(ios(14)){
+    KVATracker.shared.appTrackingTransparency.enabledBool = YES;
+
     return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceKochava) returnCode:MPKitReturnCodeSuccess];
 }
 


### PR DESCRIPTION
After hunting through documentation and their code this seemed like the optimal way to support their design for IDFA. They don't actually expose a way to ingest the state. Instead they offer a way to collect it for you and/or designate whether or not the client is using ATT/IDFA. So this defaults ATT/IDFA as not enabled and when ATTStatus is set we set it to enabled.

There last entry "Custom Prompt Timing (Optional)" is what led me to this solution. https://support.kochava.com/sdk-integration/ios-sdk-integration/ios-using-the-sdk/?scrollto=marker_9