### PR TITLE
Update Deferred Deeplinking

### DIFF
--- a/mParticle-Kochava/MPKitKochava.h
+++ b/mParticle-Kochava/MPKitKochava.h
@@ -14,6 +14,7 @@ extern NSString * _Nonnull const MPKitKochavaEnhancedDeeplinkRawKey;
 @interface MPKitKochava : NSObject <MPKitProtocol>
 
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
+@property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
 @property (nonatomic, strong, nullable) MPKitAPI *kitApi;
 

--- a/mParticle-Kochava/MPKitKochava.m
+++ b/mParticle-Kochava/MPKitKochava.m
@@ -268,7 +268,8 @@ NSString *const kvEventTypeStringProductImpression = @"ProductImpression";
     {
         [KVADeeplink processWithURL:nil completionHandler:^(KVADeeplink * _Nonnull deeplink)
          {
-            if (!deeplink) {
+            NSString *destinationString = deeplink.destinationString;
+            if (destinationString.length == 0) {
                 [self->_kitApi onAttributionCompleteWithResult:nil error:[self errorWithMessage:@"Received nil deeplink from Kochava"]];
                 return;
             }
@@ -407,7 +408,8 @@ NSString *const kvEventTypeStringProductImpression = @"ProductImpression";
     NSURL *url = userActivity.webpageURL;
     
     [KVADeeplink processWithURL:url completionHandler:^(KVADeeplink * _Nonnull deeplink) {
-        if (!deeplink) {
+        NSString *destinationString = deeplink.destinationString;
+        if (destinationString.length == 0) {
             [self->_kitApi onAttributionCompleteWithResult:nil error:[self errorWithMessage:@"Received nil deeplink from Kochava"]];
             return;
         }

--- a/mParticle-Kochava/MPKitKochava.m
+++ b/mParticle-Kochava/MPKitKochava.m
@@ -275,9 +275,8 @@ NSString *const kvEventTypeStringProductImpression = @"ProductImpression";
             }
             
             NSMutableDictionary *innerDictionary = [NSMutableDictionary dictionary];
-            if (deeplink.destinationString) {
-                innerDictionary[MPKitKochavaEnhancedDeeplinkDestinationKey] = deeplink.destinationString;
-            }
+            innerDictionary[MPKitKochavaEnhancedDeeplinkDestinationKey] = destinationString;
+
             if (deeplink.rawDictionary) {
                 innerDictionary[MPKitKochavaEnhancedDeeplinkRawKey] = deeplink.rawDictionary;
             }
@@ -415,9 +414,8 @@ NSString *const kvEventTypeStringProductImpression = @"ProductImpression";
         }
         
         NSMutableDictionary *innerDictionary = [NSMutableDictionary dictionary];
-        if (deeplink.destinationString) {
-            innerDictionary[MPKitKochavaEnhancedDeeplinkDestinationKey] = deeplink.destinationString;
-        }
+        innerDictionary[MPKitKochavaEnhancedDeeplinkDestinationKey] = destinationString;
+
         if (deeplink.rawDictionary) {
             innerDictionary[MPKitKochavaEnhancedDeeplinkRawKey] = deeplink.rawDictionary;
         }


### PR DESCRIPTION
The Kochava callback 'KVADeeplink processWithURL' should be called from both 'continueuseractivity' and 'didFinishLaunchingWithOptions'. However in our kit we only call it from continueuseractivity as we did not have access to 'didFinishLaunchingWithOptions' in the kit. 

This change ensures that the launchOptions provided in 'didFinishLaunchingWithOptions' are available in the kit so that we correctly only call 'KVADeeplink processWithURL' only on first launch. 
<img width="843" alt="Screen Shot 2021-06-14 at 4 43 57 PM" src="https://user-images.githubusercontent.com/33703490/121956940-b93ef500-cd2f-11eb-86d4-ef3049190510.png">
