### PR TITLE
Add publicHeadersPath to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
         .target(
             name: "mParticle-Kochava",
             dependencies: ["mParticle-Apple-SDK", "KochavaCore", "KochavaTracker", "KochavaAdNetwork"],
-            path: "mParticle-Kochava"),
+            path: "mParticle-Kochava",
+            publicHeadersPath: "."),
     ]
 )


### PR DESCRIPTION
# Summary

This PR adds a `publicHeadersPath` entry, which allows SPM to find headers for the creation of a module that can be imported.
