### PR TITLE
feat: Improve Privacy Manifest support for iOS 17

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(
             name: "mParticle-Apple-SDK",
             url: "https://github.com/mParticle/mparticle-apple-sdk",
-            .upToNextMajor(from: "8.19.0")
+            .upToNextMajor(from: "8.22.0")
         ),
         .package(
             name: "KochavaNetworking",
@@ -43,11 +43,13 @@ let package = Package(
             name: "mParticle-Kochava",
             dependencies: ["mParticle-Apple-SDK", "KochavaNetworking", "KochavaMeasurement", "KochavaTracking"],
             path: "mParticle-Kochava",
+            resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."),
         .target(
             name: "mParticle-Kochava-NoTracking",
             dependencies: ["mParticle-Apple-SDK", "KochavaNetworking", "KochavaMeasurement"],
             path: "mParticle-Kochava-NoTracking",
+            resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."),
     ]
 )

--- a/mParticle-Kochava/PrivacyInfo.xcprivacy
+++ b/mParticle-Kochava/PrivacyInfo.xcprivacy
@@ -7,12 +7,8 @@
     <key>NSPrivacyTrackingDomains</key>
     <array/>
     <key>NSPrivacyCollectedDataTypes</key>
-    <array>
-        <dict/>
-    </array>
+    <array/>
     <key>NSPrivacyAccessedAPITypes</key>
-    <array>
-        <dict/>
-    </array>
+    <array/>
 </dict>
 </plist>


### PR DESCRIPTION
 ## Summary
 - Fix parsing issue due to empty dict
 - Ensure manifest is included by SPM
 - Ensure that the Kochava tracking package is NOT included in the NoTracking target

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed in SPM test app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6413